### PR TITLE
Update quake.go

### DIFF
--- a/pkg/task/onlineapi/quake.go
+++ b/pkg/task/onlineapi/quake.go
@@ -175,7 +175,7 @@ func (q *Quake) Run(query string, apiKey string, pageIndex int, pageSize int, co
 	}
 	jsonData, _ := json.Marshal(data)
 	var request *http.Request
-	request, err = http.NewRequest("POST", "https://quake.360.cn/api/v3/search/quake_service", bytes.NewBuffer(jsonData))
+	request, err = http.NewRequest("POST", "https://quake.360.net/api/v3/search/quake_service", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
quake的域名从quake.360.cn 变更为quake.360.net